### PR TITLE
Admin protection

### DIFF
--- a/gallery/admin.py
+++ b/gallery/admin.py
@@ -15,8 +15,8 @@ class PhotoAdmin(TranslatableAdmin):
         """
         if obj.image:
             try:
-                width = min(obj.image.width, 100)
-                height = min(obj.image.height, 100)
+                width = min(obj.image.width or 100, 100)
+                height = min(obj.image.height or 100, 100)
                 return mark_safe(f'<img src="{obj.image.url}" width="{width}" height="{height}" />')
             except Exception:
                 pass

--- a/gallery/tests/test_admin.py
+++ b/gallery/tests/test_admin.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for the admin module.
+
+Tests for the custom `save_model()' override and the `thumbnail()' method
+"""
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from gallery.admin import PhotoAdmin, VideoAdmin
+from gallery.models import Photo, Video
+
+
+class PhotoAdminTests(TestCase):
+    """
+    Test the save_model() override and thumbnail() method for the PhotoAdmin class
+    """
+
+    def tearDown(self) -> None:
+        Photo.objects.all().delete()
+
+    def test_save_model(self):
+        """
+        Test that the save_model() override creates a translation
+        """
+        admin = PhotoAdmin(model=Photo, admin_site=None)
+        obj = Photo(
+            title="Test Photo",
+            image="test.jpg",
+            description="Test Description",
+            date="2019-01-01",
+            live=True,
+        )
+        admin.save_model(request=None, obj=obj, form=None, change=None)
+        self.assertTrue(obj.has_translation(obj.get_switch_language()))
+
+    def test_thumbnail(self):
+        """
+        Test that the thumbnail() method returns an image tag
+        """
+        admin = PhotoAdmin(model=Photo, admin_site=None)
+        obj = Photo(
+            title="Test Photo",
+            image=SimpleUploadedFile("test.jpg", b"file_content", content_type="image/jpeg"),
+            description="Test Description",
+            date="2019-01-01",
+            live=True,
+        )
+        self.assertEqual(admin.thumbnail(obj), '<img src="/media/test.jpg" width="100" height="100" />')
+
+    def test_thumbnail_no_image(self):
+        """
+        Test that the thumbnail() method returns a dash when there is no image
+        """
+        admin = PhotoAdmin(model=Photo, admin_site=None)
+        obj = Photo(
+            title="Test Photo",
+            description="Test Description",
+            date="2019-01-01",
+            live=True,
+        )
+        self.assertEqual(admin.thumbnail(obj), '-')
+
+    def test_thumbnail_invalid_image(self):
+        """
+        Test that the thumbnail() method returns a dash when the image is invalid
+        """
+        admin = PhotoAdmin(model=Photo, admin_site=None)
+        obj = Photo(
+            title="Test Photo",
+            description="Test Description",
+            image="test.txt",
+        )
+        self.assertEqual(admin.thumbnail(obj), '-')
+
+
+class VideoAdminTests(TestCase):
+    """
+    Test the save_model() override for the VideoAdmin class
+    """
+
+    def tearDown(self) -> None:
+        Video.objects.all().delete()
+
+    def test_save_model(self):
+        """
+        Test that the save_model() override creates a translation
+        """
+        admin = VideoAdmin(model=Video, admin_site=None)
+        obj = Video(
+            title="Test Video",
+            description="Test Description",
+            video='https://www.youtube.com/watch?v=9bZkp7q19f0',
+            live=True,
+        )
+        admin.save_model(request=None, obj=obj, form=None, change=None)
+        self.assertTrue(obj.has_translation(obj.get_switch_language()))

--- a/gallery/tests/test_views.py
+++ b/gallery/tests/test_views.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for the gallery views module.
+"""
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from gallery.models import Photo, Video
+from gallery import views
+
+
+def test_url_getter():
+    """
+    Test that the url_getter() function returns a function that returns the correct URL
+    """
+    get_url = views.url_getter('photos')
+    assert get_url('en') == '/en/gallery/photos/'
+    assert get_url('ja') == '/ja/gallery/photos/'
+
+    get_url = views.url_getter('videos')
+    assert get_url('en') == '/en/gallery/videos/'
+    assert get_url('ja') == '/ja/gallery/videos/'
+
+
+class GalleryViewTests(TestCase):
+    """
+    Test the gallery views
+    """
+
+    def setUp(self) -> None:
+        self.photo = Photo.objects.create(
+            title="Test Photo",
+            image=SimpleUploadedFile("test.jpg", b"file_content", content_type="image/jpeg"),
+            description="Test Photo Description",
+        )
+        self.video = Video.objects.create(
+            title="Test Video",
+            video="https://www.youtube.com/watch?v=9bZkp7q19f0",
+            description="Test Video Description",
+        )
+
+    def tearDown(self) -> None:
+        Photo.objects.all().delete()
+        Video.objects.all().delete()
+
+    def test_photos_view(self):
+        """
+        Test that the photos view returns the correct response
+        """
+        response = self.client.get('/gallery/photos/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'gallery/photos.html')
+
+    def test_videos_view(self):
+        """
+        Test that the videos view returns the correct response
+        """
+        response = self.client.get('/gallery/videos/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'gallery/videos.html')
+
+    def test_photo_detail_view(self):
+        """
+        Test that the photo detail view returns the correct response
+        """
+        response = self.client.get(f'/gallery/photos/{self.photo.pk}/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'gallery/photo_detail.html')
+
+    def test_video_detail_view(self):
+        """
+        Test that the video detail view returns the correct response
+        """
+        response = self.client.get(f'/gallery/videos/{self.video.pk}/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'gallery/video_detail.html')

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-03 11:07+0000\n"
+"POT-Creation-Date: 2024-01-05 05:27+0000\n"
 "PO-Revision-Date: 2024-01-03 15:09+0000\n"
 "Last-Translator:   <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Translated-Using: django-rosetta 0.10.0\n"
 
-#: gallery/admin.py:24 pages/admin.py:47
+#: gallery/admin.py:24 pages/admin.py:62
 msgid "Thumbnail"
 msgstr "サムネイル"
 
@@ -123,8 +123,7 @@ msgstr "会場"
 msgid "READ MORE"
 msgstr "続きを読む"
 
-#: pages/templates/pages/home.html:68
-#: pages/templates/pages/news_detail.html:30
+#: pages/templates/pages/home.html:68 pages/templates/pages/news_detail.html:30
 msgid "VIEW ALL NEWS ARTICLES"
 msgstr "すべてのニュースを表示"
 

--- a/murasaki/urls.py
+++ b/murasaki/urls.py
@@ -33,6 +33,8 @@ urlpatterns = i18n_patterns(
       path('ckeditor/', include('ckeditor_uploader.urls')),
   ]
 
+# The `static` method only works for debug mode.
+# Otherwise we need to serve the media files ourselves.
 if settings.DEBUG:
     urlpatterns = urlpatterns + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 else:
@@ -41,5 +43,3 @@ else:
             'document_root': settings.MEDIA_ROOT,
         }),
     ]
-
-

--- a/pages/admin.py
+++ b/pages/admin.py
@@ -7,7 +7,22 @@ from .models import Page, NewsItem, TourDate
 
 
 class PageAdmin(TranslatableAdmin):
+    """
+    Admin for the Page model.
+
+    We prevent creation and deletion from the admin interface.
+    This is because pages are singletons; we want them created once and not added or removed.
+
+    Additionally, we prevent changing the page type.
+    """
     list_display = ('title', 'page_type')
+    readonly_fields = ('page_type',)
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 class TourDateAdmin(TranslatableAdmin):

--- a/pages/admin.py
+++ b/pages/admin.py
@@ -38,8 +38,8 @@ class NewsItemAdmin(TranslatableAdmin):
         """
         if obj.image:
             try:
-                width = min(obj.image.width, 100)
-                height = min(obj.image.height, 100)
+                width = min(obj.image.width or 100, 100)
+                height = min(obj.image.height or 100, 100)
                 return mark_safe(f'<img src="{obj.image.url}" width="{width}" height="{height}" />')
             except Exception:
                 pass

--- a/pages/tests/test_admin.py
+++ b/pages/tests/test_admin.py
@@ -7,8 +7,33 @@ Tests for the custom `save_model()' override
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
-from pages.admin import TourDateAdmin, NewsItemAdmin
-from pages.models import TourDate, NewsItem
+from pages.admin import PageAdmin, TourDateAdmin, NewsItemAdmin
+from pages.models import Page, TourDate, NewsItem
+
+
+class PageAdminTests(TestCase):
+    """
+    Test the custom functionality of the PageAdmin class:
+        - creation prevented
+        - deletion prevented
+    """
+
+    def tearDown(self) -> None:
+        Page.objects.all().delete()
+
+    def test_has_add_permission(self):
+        """
+        Test that the add permission is disabled
+        """
+        admin = PageAdmin(model=Page, admin_site=None)
+        self.assertFalse(admin.has_add_permission(request=None))
+
+    def test_has_delete_permission(self):
+        """
+        Test that the delete permission is disabled
+        """
+        admin = PageAdmin(model=Page, admin_site=None)
+        self.assertFalse(admin.has_delete_permission(request=None))
 
 
 class TourDateAdminTests(TestCase):

--- a/pages/tests/test_admin.py
+++ b/pages/tests/test_admin.py
@@ -4,6 +4,7 @@ Unit tests for the admin module.
 Tests for the custom `save_model()' override
 """
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from pages.admin import TourDateAdmin, NewsItemAdmin
@@ -12,7 +13,8 @@ from pages.models import TourDate, NewsItem
 
 class TourDateAdminTests(TestCase):
     """
-    Test the save_model() override for the TourDateAdmin class
+    Test:
+      - the save_model() override for the TourDateAdmin class
     """
 
     def tearDown(self) -> None:
@@ -36,7 +38,9 @@ class TourDateAdminTests(TestCase):
 
 class NewsItemAdminTests(TestCase):
     """
-    Test the save_model() override for the NewsItemAdmin class
+    Test:
+     - the save_model() override for the NewsItemAdmin class
+     - the thumbnail() method for the NewsItemAdmin class
     """
 
     def tearDown(self) -> None:
@@ -55,3 +59,47 @@ class NewsItemAdminTests(TestCase):
         )
         admin.save_model(request=None, obj=obj, form=None, change=None)
         self.assertTrue(obj.has_translation(obj.get_switch_language()))
+
+    def test_thumbnail_short_description(self):
+        """
+        Test that the thumbnail() method returns a short description
+        """
+        admin = NewsItemAdmin(model=NewsItem, admin_site=None)
+        self.assertEqual(admin.thumbnail.short_description, "Thumbnail")
+
+    def test_thumbnail(self):
+        """
+        Test that the thumbnail() method returns an image tag
+        """
+        admin = NewsItemAdmin(model=NewsItem, admin_site=None)
+        obj = NewsItem(
+            title="Test News Item",
+            body="Test Body",
+            image=SimpleUploadedFile("test.jpg", b"file_content", content_type="image/jpeg"),
+            live=True,
+        )
+        self.assertEqual(admin.thumbnail(obj), '<img src="/media/test.jpg" width="100" height="100" />')
+
+    def test_thumbnail_no_image(self):
+        """
+        Test that the thumbnail() method returns a dash when there is no image
+        """
+        admin = NewsItemAdmin(model=NewsItem, admin_site=None)
+        obj = NewsItem(
+            title="Test News Item",
+            body="Test Body",
+            live=True,
+        )
+        self.assertEqual(admin.thumbnail(obj), "-")
+
+    def test_thumbnail_invalid_image(self):
+        """
+        Test that the thumbnail() method returns a dash when there is an invalid image
+        """
+        admin = NewsItemAdmin(model=NewsItem, admin_site=None)
+        obj = NewsItem(
+            title="Test News Item",
+            body="Test Body",
+            image='foo.txt',
+        )
+        self.assertEqual(admin.thumbnail(obj), "-")


### PR DESCRIPTION
Prevent addition/deletion of page objects, since these are singletons.
Also, page type cannot be edit for same reason.